### PR TITLE
add import/export xml for uabe

### DIFF
--- a/UABEAvalonia/AssetImportExport.cs
+++ b/UABEAvalonia/AssetImportExport.cs
@@ -44,6 +44,9 @@ namespace UABEAvalonia
             doc.Save(path);
         }
 
+        /**
+         * this method 's logic fully copy from dump text asset
+         */
         private XmlNode DumpXmlNode(XmlDocument doc, AssetTypeValueField field) {
             AssetTypeTemplateField template = field.GetTemplateField();
             string align = template.align ? true.ToString() : false.ToString();
@@ -299,6 +302,9 @@ namespace UABEAvalonia
             return new BundleReplacerFromMemory(name, name, isSerialized, data, -1);
         }
 
+        /**
+         * @return is anything wrote
+         */
         public static bool writeData(AssetsFileWriter asset, string name, string value)
         {
             bool writed = true;
@@ -349,6 +355,10 @@ namespace UABEAvalonia
             return writed;
         }
 
+        /**
+         * all logic is rewrite from ImportTextAssetLoop
+         * xml is more readable than text, and they can be easily modify by other program or function
+         */
         public static byte[]? ImportXml(string path)
         {
             try
@@ -359,8 +369,17 @@ namespace UABEAvalonia
                 using (XmlReader reader = XmlReader.Create(File.OpenRead(path)))
                 {
                     string? lastValue = null;
+                    /**
+                     * store every node 's align requirement info;
+                     */
                     Stack<bool> alignStack = new Stack<bool>();
+                    /**
+                     * every array data 's MemoryStream, when reach end of array they will append on mainStream;
+                     */
                     Stack<Stream> streams = new Stack<Stream>();
+                    /**
+                     * count every object/array node's direct sub child
+                     */
                     Stack<int> objectCount = new Stack<int>();
                     while (reader.Read())
                     {
@@ -426,6 +445,9 @@ namespace UABEAvalonia
                                     streams.TryPeek(out Stream? next);
                                     var topStream = next ?? mainStream;
                                     long currentSize = mainStream.Length;
+                                    /** 
+                                     * count length
+                                     */
                                     foreach (var item in streams.ToArray())
                                     {
                                         currentSize += item.Length;

--- a/UABEAvalonia/InfoWindow.axaml.cs
+++ b/UABEAvalonia/InfoWindow.axaml.cs
@@ -156,6 +156,7 @@ namespace UABEAvalonia
             sfd.Title = "Save As";
             sfd.Filters = new List<FileDialogFilter>() {
                 new FileDialogFilter() { Name = "UABE text dump", Extensions = new List<string>() { "txt" } },
+                new FileDialogFilter() { Name = "UABE xml dump", Extensions = new List<string>() { "xml" } },
                 new FileDialogFilter() { Name = "UABE json dump", Extensions = new List<string>() { "json" } }
             };
 
@@ -163,18 +164,30 @@ namespace UABEAvalonia
 
             if (file != null && file != string.Empty)
             {
+                AssetImportExport dumper = new AssetImportExport();
                 if (file.EndsWith(".json"))
                 {
                     await MessageBoxUtil.ShowDialog(this, "Not implemented", "There's no json dump support yet, sorry. Exporting as .txt anyway.");
                     file = file.Substring(0, file.Length - 5) + ".txt";
+                    using (FileStream fs = File.OpenWrite(file))
+                    using (StreamWriter sw = new StreamWriter(fs))
+                    {
+                        dumper.DumpTextAsset(sw, GetSelectedField());
+                    }
+                }
+                else if (file.EndsWith(".xml"))
+                {
+                   dumper.DumpXmlAsset(file, GetSelectedField());
+                }
+                else {
+                    using (FileStream fs = File.OpenWrite(file))
+                    using (StreamWriter sw = new StreamWriter(fs))
+                    {
+                        dumper.DumpTextAsset(sw, GetSelectedField());
+                    }
                 }
 
-                using (FileStream fs = File.OpenWrite(file))
-                using (StreamWriter sw = new StreamWriter(fs))
-                {
-                    AssetImportExport dumper = new AssetImportExport();
-                    dumper.DumpTextAsset(sw, GetSelectedField());
-                }
+
             }
         }
 


### PR DESCRIPTION
xml is more readable than text, and they can be easily modify by other program or function

current work fine with https://github.com/HxBreak/AssetsTools.NET/tree/d6ddbe485f5e5937f6a21c18625f02e7b59ce37f
when merge AssetsTools.NET to latest version it will go crash in parse assets bundle.

## preview
![20210413212219](https://user-images.githubusercontent.com/15846180/114559747-a1e77b00-9c9e-11eb-976a-6894ad6d6ec4.png)

