### PR TITLE
fix some bugs at the TexturePlugin

### DIFF
--- a/TexturePlugin/Program.cs
+++ b/TexturePlugin/Program.cs
@@ -156,10 +156,12 @@ namespace TexturePlugin
                 bool success = await ImportTextures(win, batchInfos);
                 if (success)
                 {
-                    //some of the assets may not get modified, but
-                    //uabe still makes replacers for those anyway
                     foreach (AssetContainer cont in selection)
                     {
+                        if (batchInfos.Where(x => x.pathId == cont.PathId).Count() == 0)
+                        {
+                            continue;
+                        }
                         byte[] savedAsset = cont.BaseValueField.WriteToByteArray();
 
                         var replacer = new AssetsReplacerFromMemory(

--- a/UABEAvalonia/ImportBatch.axaml.cs
+++ b/UABEAvalonia/ImportBatch.axaml.cs
@@ -70,7 +70,10 @@ namespace UABEAvalonia
                     .Select(f => Path.GetFileName(f)).ToList();
                 gridItem.matchingFiles = matchingFiles;
                 gridItem.selectedIndex = matchingFiles.Count > 0 ? 0 : -1;
-                gridItems.Add(gridItem);
+                if (gridItem.matchingFiles.Count > 0)
+                {
+                    gridItems.Add(gridItem);
+                }
             }
             dataGrid.Items = gridItems;
         }


### PR DESCRIPTION
1. Show only modified textures in the "Batch import" dialog.
2. Replace and mark only modified textures in the "Assets Info" window.