### PR TITLE
fix batchimportbundle command

### DIFF
--- a/UABEAvalonia/CommandLineHandler.cs
+++ b/UABEAvalonia/CommandLineHandler.cs
@@ -192,13 +192,13 @@ namespace UABEAvalonia
                 for (int i = 0; i < entryCount; i++)
                 {
                     string name = bun.BlockAndDirInfo.DirectoryInfos[i].Name;
-                    string matchName = Path.Combine(file, $"{Path.GetFileName(file)}_{name}.assets");
+                    string matchName = Path.Combine(importDirectory, $"{Path.GetFileName(file)}_{name}.assets");
 
                     if (File.Exists(matchName))
                     {
                         FileStream fs = File.OpenRead(matchName);
                         long length = fs.Length;
-                        reps.Add(new BundleReplacerFromStream(matchName, matchName, true, fs, 0, length));
+                        reps.Add(new BundleReplacerFromStream(name, name, true, fs, 0, length));
                         streams.Add(fs);
                         Console.WriteLine($"Importing {matchName}...");
                     }


### PR DESCRIPTION
Closes #209

Relatively tiny pr to fix the `batchimportbundle` command, it used some wrong variable names which resulted in the wrong paths being looked for, and as such no files being imported into the bundle.
Feel free to disregard, as I've seen your plans on the alternative direction of the commandline tool, but this should be a good solution for now in terms of issues like the one above.