### PR TITLE
Update FileTypeDetector to include dashes in custom unity versions

### DIFF
--- a/UABEAvalonia/Logic/FileTypeDetector.cs
+++ b/UABEAvalonia/Logic/FileTypeDetector.cs
@@ -44,8 +44,8 @@ namespace UABEAvalonia
                     break;
                 }
             }
-            emptyVersion = Regex.Replace(possibleVersion, "[a-zA-Z0-9\\.\\n]", "");
-            fullVersion = Regex.Replace(possibleVersion, "[^a-zA-Z0-9\\.\\n]", "");
+            emptyVersion = Regex.Replace(possibleVersion, "[a-zA-Z0-9\\.\\n\\-]", "");
+            fullVersion = Regex.Replace(possibleVersion, "[^a-zA-Z0-9\\.\\n\\-]", "");
 
             if (possibleBundleHeader == "UnityFS")
             {


### PR DESCRIPTION
Custom Unity versions are not detected properly, i.e. if the unity version is 2021.3.9f1-gamename, the file type detector doesn't parse it correctly.

To fix https://github.com/nesrak1/UABEA/issues/286