### PR TITLE
Let 'import raw' support match assetName

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: windows-2022
-
+    
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/UABEAvalonia/Forms/ImportBatch.axaml.cs
+++ b/UABEAvalonia/Forms/ImportBatch.axaml.cs
@@ -32,7 +32,8 @@ namespace UABEAvalonia
             ignoreListEvents = false;
         }
 
-        public ImportBatch(AssetWorkspace workspace, List<AssetContainer> selection, string directory, List<string> extensions) : this()
+        public ImportBatch(AssetWorkspace workspace, List<AssetContainer> selection, string directory,
+            List<string> extensions) : this()
         {
             this.workspace = workspace;
             this.directory = directory;
@@ -65,7 +66,8 @@ namespace UABEAvalonia
                 
                 if (!anyExtension)
                     matchingFiles = filesInDir
-                        .Where(f => extensions.Any(x => f.EndsWith(gridItem.GetMatchName(x))))
+                        .Where(f => extensions.Any(x =>
+                            f.EndsWith(gridItem.GetMatchName(x)) || f.StartsWith(gridItem.importInfo.assetName)))
                         .Select(f => Path.GetFileName(f)).ToList();
                 else
                     matchingFiles = filesInDir
@@ -141,9 +143,20 @@ namespace UABEAvalonia
     {
         public ImportBatchInfo importInfo;
 
-        public string Description { get => importInfo.assetName; }
-        public string File { get => importInfo.assetFile; }
-        public long PathID { get => importInfo.pathId; }
+        public string Description
+        {
+            get => importInfo.assetName;
+        }
+
+        public string File
+        {
+            get => importInfo.assetFile;
+        }
+
+        public long PathID
+        {
+            get => importInfo.pathId;
+        }
 
         public List<string> matchingFiles;
         public int selectedIndex;
@@ -157,6 +170,7 @@ namespace UABEAvalonia
             else
                 return $"-{File}-{PathID}";
         }
+
         public void Update(string propertyName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/UABEAvalonia/Forms/ImportBatch.axaml.cs
+++ b/UABEAvalonia/Forms/ImportBatch.axaml.cs
@@ -67,7 +67,7 @@ namespace UABEAvalonia
                 if (!anyExtension)
                     matchingFiles = filesInDir
                         .Where(f => extensions.Any(x =>
-                            f.EndsWith(gridItem.GetMatchName(x)) || f.StartsWith(gridItem.importInfo.assetName)))
+                            f.EndsWith(gridItem.GetMatchName(x)) || Path.GetFileName(f).StartsWith(gridItem.importInfo.assetName)))
                         .Select(f => Path.GetFileName(f)).ToList();
                 else
                     matchingFiles = filesInDir


### PR DESCRIPTION
This feature may seem a bit strange,But I mod some animation clip way is 

- use other tools to restore to Unity project 
- in Unity editor mod clip 
- pack modded assetbundle
- use uabe to export modded clip raw
- use uabe to import modded clip raw to replace original asset bundle 


so this feature can let me skip renaming steps